### PR TITLE
Smoke test to ensure Ingress works

### DIFF
--- a/tests/01-ingress-http-traffic/ing-smoketest.sh
+++ b/tests/01-ingress-http-traffic/ing-smoketest.sh
@@ -6,7 +6,7 @@ sleep 3
 
 kubectl -n ingress-smoketest apply -f ./ingress-smoketest.yaml
 
-sleep 3
+sleep 15
 
 output=$(curl -s -o /dev/null -w "%{http_code}" https://ingress-smoketest-app.apps.cloud-platform-test-1.k8s.integration.dsd.io)
 

--- a/tests/01-ingress-http-traffic/ing-smoketest.sh
+++ b/tests/01-ingress-http-traffic/ing-smoketest.sh
@@ -19,6 +19,8 @@ then
     exit 0
 else
     echo "Ingress Test Failed!"
+    eoutput=$(curl -s -o -v /dev/null https://ingress-smoketest-app.apps.cloud-platform-test-1.k8s.integration.dsd.io)
+    echo $eoutput
     exit 1
 fi;
 

--- a/tests/01-ingress-http-traffic/ing-smoketest.sh
+++ b/tests/01-ingress-http-traffic/ing-smoketest.sh
@@ -8,7 +8,7 @@ kubectl -n ingress-smoketest apply -f ./ingress-smoketest.yaml
 
 sleep 3
 
-output=$(curl -s -o /dev/null -w "%{http_code}" https://iingress-smoketest-app.apps.cloud-platform-test-1.k8s.integration.dsd.io)
+output=$(curl -s -o /dev/null -w "%{http_code}" https://ingress-smoketest-app.apps.cloud-platform-test-1.k8s.integration.dsd.io)
 
 echo $output
 

--- a/tests/01-ingress-http-traffic/ing-smoketest.sh
+++ b/tests/01-ingress-http-traffic/ing-smoketest.sh
@@ -8,15 +8,13 @@ kubectl -n ingress-smoketest apply -f ./ingress-smoketest.yaml
 
 sleep 3
 
-#set -e
-curl -f -s -o /dev/null https://iingress-smoketest-app.apps.cloud-platform-test-1.k8s.integration.dsd.io 
-echo $?
+output=$(curl -s -o /dev/null -w "%{http_code}" https://iingress-smoketest-app.apps.cloud-platform-test-1.k8s.integration.dsd.io)
 
-use $?
+echo $output
 
-if [ $? -eq 0 ]; 
+if [ "$output" -eq 200 ]; 
 then
-    echo "Ingress Test Successfull"
+    echo "Ingress Test Successfull!"
     kubectl delete namespace ingress-smoketest
     exit 0
 else

--- a/tests/01-ingress-http-traffic/ing-smoketest.sh
+++ b/tests/01-ingress-http-traffic/ing-smoketest.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+kubectl create namespace ingress-smoketest
+
+sleep 3
+
+kubectl -n ingress-smoketest apply -f ./ingress-smoketest.yaml
+
+sleep 3
+
+#set -e
+curl -f -s -o /dev/null https://iingress-smoketest-app.apps.cloud-platform-test-1.k8s.integration.dsd.io 
+echo $?
+
+use $?
+
+if [ $? -eq 0 ]; 
+then
+    echo "Ingress Test Successfull"
+    kubectl delete namespace ingress-smoketest
+    exit 0
+else
+    echo "Ingress Test Failed!"
+    exit 1
+fi;
+

--- a/tests/01-ingress-http-traffic/ingress-smoketest.yaml
+++ b/tests/01-ingress-http-traffic/ingress-smoketest.yaml
@@ -42,3 +42,4 @@ spec:
         backend:
           serviceName: ingress-smoketest-svc
           servicePort: 80
+          

--- a/tests/01-ingress-http-traffic/ingress-smoketest.yaml
+++ b/tests/01-ingress-http-traffic/ingress-smoketest.yaml
@@ -1,0 +1,44 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ingress-smoketest-app
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ingress-smoketest-app
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-smoketest-svc
+  labels:
+    app: ingress-smoketest-svc
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 80
+  selector:
+    app: ingress-smoketest-app
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-smoketest-app-ing
+spec:
+  rules:
+  - host: ingress-smoketest-app.apps.cloud-platform-test-1.k8s.integration.dsd.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ingress-smoketest-svc
+          servicePort: 80

--- a/tests/01-ingress-http-traffic/test.sh
+++ b/tests/01-ingress-http-traffic/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo Start Ingress Smoke Test....
+
 kubectl create namespace ingress-smoketest
 
 sleep 3
@@ -16,11 +18,13 @@ if [ "$output" -eq 200 ];
 then
     echo "Ingress Test Successfull!"
     kubectl delete namespace ingress-smoketest
+    echo End of Ingress Smoke Test
     exit 0
 else
     echo "Ingress Test Failed!"
     eoutput=$(curl -s -o -v /dev/null https://ingress-smoketest-app.apps.cloud-platform-test-1.k8s.integration.dsd.io)
     echo $eoutput
+    echo End of Ingress Smoke Test
     exit 1
 fi;
 


### PR DESCRIPTION
WHAT
Setup a test that creates a temporary namespace, launches a service with an HTTP listener, a Service and an Ingress and test that you can hit the URL and get a 200 OK and then clean up namespace.

WHY
This will eventually be used as an automated test run on a schedule to test ingress on a given cluster