### PR TITLE
Smoke test for Log Collection

### DIFF
--- a/tests/02-log-collection
+++ b/tests/02-log-collection
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+kubectl create namespace log-collection-test
+kubectl run wordpress --image wordpress -n log-collection-test
+
+while true ; do 
+    echo "Working..."
+    result=$(kubectl describe pods -n log-collection-test | grep 'Pending')
+    echo "Result found is $result"
+  if [[ -z $result ]] ; then 
+    echo "Complete"
+    break
+  fi
+done
+
+sleep 60
+
+export pod_name=`kubectl get pods -n log-collection-test | awk 'FNR == 2 {print $1}'`
+export date=`date +%Y.%m.%d`
+export curlresult=$(curl -s -XGET http://search-cloud-platform-test-o2m2taivvjpovbcl63mlytnpua.eu-west-1.es.amazonaws.com/logstash-$date/_search -H 'Content-Type: application/json' -d'
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "kubernetes.namespace_name": "log-collection-test"
+          }
+        },
+        {
+          "match": {
+            "kubernetes.pod_name": "'"$pod_name"'" 
+          }
+        }
+      ]
+    }
+  }
+}' | jq .hits.total)
+
+printenv curlresult
+
+if [ $curlresult == 0 ] 
+  then  
+    echo "Test Failed"
+    exit 1
+  else
+    echo "Test Passed"
+    kubectl delete pod $pod_name -n log-collection-test
+    kubectl delete namespace log-collection-test
+    exit 0
+fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -29,7 +29,7 @@ export curlresult=$(curl -s -XGET http://search-cloud-platform-test-o2m2taivvjpo
         },
         {
           "match": {
-            "kubernetes.pod_name": "'"$pod_name"'" 
+            "kubernetes.pod_name.keyword": "'"$pod_name"'" 
           }
         }
       ]


### PR DESCRIPTION
connects to ministryofjustice/cloud-platform#400

**WHAT**
Log Collection smoke test script that creates a namespace, deploys wordpress and performs an API call to elasticsearch to retrieve logs for the recent wordpress deployment. If logs are present then the test will pass and if they are not, the test will fail with an exit 1 code. 

**WHY**
To ensure that logs are collected and passed to elasticsearch


Note: The smoke test currently only works in `test-1`. When integrated with the pipeline, the elasticsearch URL will be an environment variable. 