### PR TITLE
Update namespace test to expect new error message

### DIFF
--- a/spec/namespace_spec.rb
+++ b/spec/namespace_spec.rb
@@ -24,12 +24,12 @@ describe "namespace" do
 
     it "does not allow non-webops to access namespace" do
       result = can_i_get "namespace", group
-      expect(result).to eq("no")
+      expect(result).to eq("no - no RBAC policy matched")
     end
 
     it "does not allow non-webops to access pods" do
       result = can_i_get "pod", group
-      expect(result).to eq("no")
+      expect(result).to eq("no - no RBAC policy matched")
     end
   end
 


### PR DESCRIPTION
The response to this command used to be "no", now
it's "no - no RBAC policy matched" I think this
changed when the cluster was upgraded to
kubernetes 1.12.10

Updated: This may only be happening to David S. so it might relate to
specific kubectl versions. A better option might be to check for /^no/
rather than an exact string.